### PR TITLE
Added the width and height property to the parent div

### DIFF
--- a/src/area.jsx
+++ b/src/area.jsx
@@ -60,7 +60,9 @@ export default class AreaChart extends Component {
     if(showYGrid) ygrid = <Ygrid/>
 
     return (
-      <div>
+      <div 
+        style={{width: width, 
+          height: height}}>
         {showLegend?
           <Legend
             {...this.props}

--- a/src/area_stack.jsx
+++ b/src/area_stack.jsx
@@ -57,7 +57,9 @@ export default class AreaStackChart extends Component {
     if(showYGrid) ygrid = <Ygrid/>
 
     return (
-      <div>
+      <div 
+        style={{width: width, 
+          height: height}}>
         {showLegend?
           <Legend
             {...this.props}

--- a/src/bar.jsx
+++ b/src/bar.jsx
@@ -61,7 +61,9 @@ export default class BarChart extends Component {
     if(showYGrid) ygrid = <Ygrid/>
 
     return (
-      <div>
+      <div 
+        style={{width: width, 
+          height: height}}>
         {showLegend?
           <Legend
             {...this.props}

--- a/src/bar_group.jsx
+++ b/src/bar_group.jsx
@@ -61,7 +61,9 @@ export default class BarGroupChart extends Component {
     if(showYGrid) ygrid = <Ygrid/>
 
     return (
-      <div>
+      <div 
+        style={{width: width, 
+          height: height}}>
         {showLegend?
           <Legend
             {...this.props}

--- a/src/bar_group_horizontal.jsx
+++ b/src/bar_group_horizontal.jsx
@@ -61,7 +61,9 @@ export default class BarGroupHorizontalChart extends Component {
     if(showYGrid) ygrid = <Ygrid/>
 
     return (
-      <div>
+      <div 
+        style={{width: width, 
+          height: height}}>
         {showLegend?
           <Legend
             {...this.props}

--- a/src/bar_horizontal.jsx
+++ b/src/bar_horizontal.jsx
@@ -61,7 +61,9 @@ export default class BarHorizontalChart extends Component {
     if(showYGrid) ygrid = <Ygrid/>
 
     return (
-      <div>
+      <div 
+        style={{width: width, 
+          height: height}}>
         {showLegend?
           <Legend
             {...this.props}

--- a/src/bar_stack.jsx
+++ b/src/bar_stack.jsx
@@ -61,7 +61,9 @@ export default class BarStackChart extends Component {
     if(showYGrid) ygrid = <Ygrid/>
 
     return (
-      <div>
+      <div 
+        style={{width: width, 
+          height: height}}>
         {showLegend?
           <Legend
             {...this.props}

--- a/src/bar_stack_horizontal.jsx
+++ b/src/bar_stack_horizontal.jsx
@@ -61,7 +61,9 @@ export default class BarStackChart extends Component {
     if(showYGrid) ygrid = <Ygrid/>
 
     return (
-      <div>
+      <div 
+        style={{width: width, 
+          height: height}}>
         {showLegend?
           <Legend
             {...this.props}

--- a/src/line.jsx
+++ b/src/line.jsx
@@ -60,7 +60,9 @@ export default class LineChart extends Component {
     if(showYGrid) ygrid = <Ygrid/>
 
     return (
-      <div>
+      <div 
+        style={{width: width, 
+          height: height}}>
         {showLegend?
           <Legend
             {...this.props}

--- a/src/pie.jsx
+++ b/src/pie.jsx
@@ -50,7 +50,9 @@ export default class PieChart extends Component {
 
 
     return (
-      <div>
+      <div 
+        style={{width: width, 
+          height: height}}>
         {showLegend?
           <Legend
             {...this.props}

--- a/src/scatter.jsx
+++ b/src/scatter.jsx
@@ -57,7 +57,9 @@ export default class ScatterPlot extends Component {
     if(showYGrid) ygrid = <Ygrid/>
 
     return (
-      <div>
+      <div 
+        style={{width: width, 
+          height: height}}>
         {showLegend?
           <Legend
             {...this.props}


### PR DESCRIPTION
The parent div of any chart elements (i.e., Bar, Line, etc., ) are not using the width and height property defined by the user. This PR will adjust the div to the proper size as per user need. Faced this issue while using adjacent bar charts with two columns in the bootstrap row.
